### PR TITLE
Duplicate "Coding Style" in TOC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ Thank you for you interest in contributing ✨
   - [Code of Conduct](#code-of-conduct)
   - [I don't want to read this whole thing, I just have a question!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
   - [What should I know before I get started?](#what-should-i-know-before-i-get-started)
-  - [Coding Style](#coding-style)
   - [Design Philosophy](#design-philosophy)
   - [Coding Style](#coding-style)
   - [Naming Conventions](#naming-conventions)


### PR DESCRIPTION
I was just reading this and noticed that "Coding Style" appears twice in the table of contents.