### PR TITLE
MAINT: Simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,18 +1,24 @@
 name: Report a problem 🐛
 description: Problem reports are for when something behaves incorrectly, or differently from how you'd expect.
-labels: bug
+labels: [bug]
 body:
 - type: textarea
   id: describe
   attributes:
-    label: Describe the problem
+    label: Describe the bug
     description: |
       Provide a short description (one or two sentences) about the problem. What did you expect to happen, and what is actually happening?
 
       If possible, provide screenshots or error messages that you've encountered.
-    placeholder: |
-      The behavior of XXX doesn't work as expected. When I do YYY, I expected ZZZ to occur, but instead WWW happens.
-
+    value: |
+      **context**
+      When I do ___.
+      
+      **expectation**
+      I expected ___ to occur.
+      
+      **bug**
+      But instead ___ happens
       Here's an error message I ran into...
 
       ```console
@@ -20,30 +26,24 @@ body:
       ERROR ...
       ```
 
-      Here's a screenshot of the problem...
-
-      ![](drag-and-drop-screenshot-image)
-
+      **problem**
+      This is a problem for people doing ___ because ___.
+      
   validations:
     required: true
-
-- type: input
-  id: example-link
-  attributes:
-    label: Link to your repository or website
-    description: |
-      If possible, provide a link to your repository or an online place where others can observe this problem.
-    placeholder: |
-      https://mybook.org/a/page/with/problems.html
-  validations:
-    required: false
 
 - type: textarea
   id: reproduce
   attributes:
-    label: Steps to reproduce
+    label: Reproduce the bug
     description: |
-      Provide information that others may use to re-produce this behavior. Provide this in a step-by-step manner so that others can follow along.
+      Provide information that others may use to re-produce this behavior.
+      For example:
+      
+      - Step-by-step instructions that others can follow.
+      - Links to a website that demonstrates the bug.
+      - Information about certain conditions that the bug pops up.
+
     placeholder: |
       1. Go to '...'
       2. Click on '....'
@@ -52,32 +52,21 @@ body:
   validations:
     required: true
 
-- type: input
-  id: python-version
-  attributes:
-    label: The version of Python you're using
-  validations:
-    required: false
-- type: input
-  id: operating-system
-  attributes:
-    label: Your operating system
-  validations:
-    required: false
 - type: textarea
-  id: package-versions
+  id: environment
   attributes:
-    label: Versions of your packages
+    label: List your environment
     description: |
-      List versions of the relevant packages in your environment needed to reproduce the error.
-      
-      **If you're using Jupyter Book**, paste the output of
-      
-      ```bash
-      jupyter-book --version
-      ```
+      List the environment needed to reproduce the error.
+      Here are a few ideas:
 
-      **If you're using another tool**, paste the versions of any relevant packages for this error.
+      - The output of:      
+        ```bash
+        jupyter-book --version
+        ```
+      - The version of Python you're using.
+      - Your operating system
+      - Versions of any other relevant tools you're using.
     placeholder: |
       ```
       ❯ jupyter-book --version
@@ -89,14 +78,5 @@ body:
         Jupyter-Cache     : 0.4.2
         NbClient          : 0.5.3
       ```
-  validations:
-    required: false
-
-- type: textarea
-  id: context
-  attributes:
-    label: Additional context
-    description: |
-      Any additional context needed to help reproduce, understand, and resolve this issue.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,51 +1,52 @@
+# Inspired by
+# - https://www.backhub.co/blog/best-practices-for-using-github-issues
+# - https://medium.com/nyc-planning-digital/writing-a-proper-github-issue-97427d62a20f
+# - https://wiredcraft.com/blog/how-we-write-our-github-issues/
 name: Request an enhancement 💡
 description: Suggest an idea for this project
-labels: enhancement
+labels: [enhancement]
 body:
 - type: textarea
   id: describe
   attributes:
-    label: Description / Summary
+    label: Describe the problem/need and solution
     description: |
-      Describe the enhancement you'd like to see. Provide as much context as possible and link to related issues and/or pull requests. Include screenshots if there is prior art you'd like to refer to.
-      This section should contain "what" you are proposing.
-    placeholder: |
-      - I wish I were able to...
-      - It would be useful if XXX behaved in YYY way...
-      - XXX feature would be better if it would...
+      - Describe the problem or need you'd like to address.
+      - Include enough context so that somebody can quickly understand the need.
+      - Note what kind of users would benefit from this solution. 
+    value: |
+      **Context**
+      In situations where you're trying to do XXX.
+
+      **Problem / Idea**
+      You also want to do YYY, but this isn't currently possible.
+
+      **Solution**
+      We could make YYY possible by adding ZZZ new features.
+
+      **Benefit**
+      This would benefit the people trying to do XXX because...
+
   validations:
     required: true
 
-- type: textarea
-  id: value
-  attributes:
-    label: Value / benefit
-    description: |
-      What is the value in resolving this issue, and who will benefit from it?
-      Include any information that could help us prioritize the enhancement.
-
-    placeholder: |
-      - This would facilitate XXX which is a common use-case
-      - It's really annoying when XXX and this would fix it
-      - This would make it possible to XXX which YYY people care about.
-
-  validations:
-    required: true
 
 - type: textarea
   id: implementation
   attributes:
-    label: Implementation details
+    label: Guide for implementation
     description: |
-      Anything that will help others understand how this issue could be addressed. Where appropriate, note locations in a codebase where a change would need to be made, or other considerations that should be taken.
-      This section should contain "how" this issue should be resolved.
-
-      _If you can't think of anything then just leave this blank and we can fill it in later! This can be filled in as we understand more about an issue._
+      Any guidance that will help others understand how this issue could be addressed.
+      Where appropriate, include:
+      
+      - locations in a codebase where a change would need to be made
+      - rough mock-ups and design-level suggestions
+      - screenshots of inspiration to take
 
     placeholder: |
       - This change would be probably need to be over here...
       - The best way to do this would be...
-      - There are a few ways to do this, we should choose between...
+      - Here are links to tools with similar features...
 
   validations:
     required: false
@@ -54,9 +55,9 @@ body:
 - type: textarea
   id: tasks
   attributes:
-    label: Tasks to complete
+    label: Tasks and updates
     description: |
-      Any concrete tasks that should be completed to resolve this issue.
+      Use this area to track ongoing work and to-do items.
       The more specific the better.
 
       _If you can't think of anything then just leave this blank and we can fill it in later! This can be filled in as we understand more about an issue._


### PR DESCRIPTION
This attempts to slightly simplify our issue templates. It doesn't make any huge changes, but does a few things to clean them up:

- Reduces the total number of fields for people to fill out, and instead gives a few prompts within fields that they can fill out if they find it useful. This should reduce the number of `no response` entries in our issues.
- Structures the information prompts based on some general best practices for issues (see [this blog post for one example](https://wiredcraft.com/blog/how-we-write-our-github-issues/)).

I was also considering lumping together `bug` and `enhancement` since a lot of the most relevant information is the same, but decided that it'd make things too complex to lump together all the "report your environment / reproduce the bug" stuff together in the same template. Curious what others think though.

fixes https://github.com/executablebooks/meta/issues/633