### PR TITLE
FIX: Update draft pull requests docs URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,7 +305,7 @@ You can also combine the tags above, for example if you are updating both a test
 PRs should also usually look to respond to one or more open issues. You can link a pull request to an issue to show that a fix is in progress and to automatically close the issue when the pull request is merged; see [Linking a pull request to an issue](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
 
 If your pull request is not yet ready to be merged, please open your pull request as a draft.
-More information about doing this is [available in GitHub's documentation](https://help.github.com/articles/about-pull-requests/#draft-pull-requests).
+More information about doing this is [available in GitHub's documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
 This tells the development team that the pull request is a "work-in-progress", and that you plan to continue working on it.
 
 When your pull request is "Ready for Review", you can select this option on the PR's page, which will notify project maintainers to review your proposed changes.


### PR DESCRIPTION
Update the URL for GitHub's documentation on draft pull requests to avoid the redirect that GitHub performs from the old URL. This is needed more broadly so that other executablebooks projects that pull in the CONTRIBUTING.md (c.f. https://github.com/executablebooks/meta/pull/83) don't have redirects in them.

Needed for https://github.com/executablebooks/meta/pull/721